### PR TITLE
add unmodified/modified to checkpointing

### DIFF
--- a/_episodes/04-staging-area.md
+++ b/_episodes/04-staging-area.md
@@ -73,25 +73,24 @@ We will now learn to fabricate nice commits using the staging area.
 ## Checkpointing using the staging area
 
 ```
-                tracked     staged   committed
-              but unstaged    |          |
-command            |          |          |   English translation
+              unmodified   modified    staged   committed
+                   |          |          |          |
+command            |          |          |          |   English translation
 
-git add file(s)    |--------->|          |   stage file
-git commit         |          |--------->|   commit staged file(s)
-git commit file(s) |-------------------->|   commit file(s) directly
+git add file(s)    |          |--------->|          |   stage file
+git commit         |          |          |--------->|   commit staged file(s)
+git commit file(s) |          |-------------------->|   commit file(s) directly
 
-git diff           |<-------->|          |   between modified and staged
-git diff --cached  |          |<-------->|   between staged and last commit
-git diff HEAD      |<------------------->|   between modified and last commit
-git diff           |<------------------->|   if nothing is staged
+git diff           |          |<-------->|          |   between modified and staged
+git diff --cached  |          |          |<-------->|   between staged and last commit
+git diff HEAD      |          |<------------------->|   between modified and last commit
+git diff           |          |<------------------->|   if nothing is staged
 
-git reset          |<---------|          |   unstage
-git reset --soft   |          |<---------|   "uncommit" and stage
-git reset --hard   |<--------------------|   discard
+git reset          |          |<---------|          |   unstage
+git reset --hard   |<---------|          |          |   discard
+git reset --hard   |<--------------------|          |   discard
 
-git checkout       |<---------|          |   undo unstaged modifications
-git checkout       |<--------------------|   if nothing is staged
+git checkout       |<---------|          |          |   undo unstaged modifications
 ```
 
 - We will discuss what the `HEAD` is in the next section.

--- a/_episodes/04-staging-area.md
+++ b/_episodes/04-staging-area.md
@@ -89,7 +89,7 @@ git diff                |          |<------------------->|   if nothing is stage
 git reset               |          |<---------|          |   unstage
 git reset --hard        |<---------|          |          |   discard
 git reset --hard        |<--------------------|          |   discard
-git reset --soft <hash> |          |<--------------------|   "uncommit" everything after <hash>
+git reset --soft <hash> |          |          |<---------|   "uncommit" everything after <hash>
 git reset --hard <hash> |<-------------------------------|   "uncommit" everything after <hash> and abandon changes
 
 git checkout            |<---------|          |          |   undo unstaged modifications

--- a/_episodes/04-staging-area.md
+++ b/_episodes/04-staging-area.md
@@ -73,24 +73,26 @@ We will now learn to fabricate nice commits using the staging area.
 ## Checkpointing using the staging area
 
 ```
-              unmodified   modified    staged   committed
-                   |          |          |          |
-command            |          |          |          |   English translation
+                   unmodified   modified    staged   committed
+                        |          |          |          |
+command                 |          |          |          |   English translation
 
-git add file(s)    |          |--------->|          |   stage file
-git commit         |          |          |--------->|   commit staged file(s)
-git commit file(s) |          |-------------------->|   commit file(s) directly
+git add file(s)         |          |--------->|          |   stage file
+git commit              |          |          |--------->|   commit staged file(s)
+git commit file(s)      |          |-------------------->|   commit file(s) directly
 
-git diff           |          |<-------->|          |   between modified and staged
-git diff --cached  |          |          |<-------->|   between staged and last commit
-git diff HEAD      |          |<------------------->|   between modified and last commit
-git diff           |          |<------------------->|   if nothing is staged
+git diff                |          |<-------->|          |   between modified and staged
+git diff --cached       |          |          |<-------->|   between staged and last commit
+git diff HEAD           |          |<------------------->|   between modified and last commit
+git diff                |          |<------------------->|   if nothing is staged
 
-git reset          |          |<---------|          |   unstage
-git reset --hard   |<---------|          |          |   discard
-git reset --hard   |<--------------------|          |   discard
+git reset               |          |<---------|          |   unstage
+git reset --hard        |<---------|          |          |   discard
+git reset --hard        |<--------------------|          |   discard
+git reset --soft <hash> |          |<--------------------|   "uncommit" everything after <hash>
+git reset --hard <hash> |<-------------------------------|   "uncommit" everything after <hash> and abandon changes
 
-git checkout       |<---------|          |          |   undo unstaged modifications
+git checkout            |<---------|          |          |   undo unstaged modifications
 ```
 
 - We will discuss what the `HEAD` is in the next section.


### PR DESCRIPTION
adding the categories of modified and unmodified files to the checkpointing using the staging area

The differences between git reset and git checkout require these specifications.

At the same time I removed
git reset --soft (which does not lead to any change in the given picture since modifications are neither deleted, nor files are moved from the staging area)
git checkout on unmodified repository (this only replicates the current status)