### PR TITLE
change reference for git diff last commit to unmodified instead of co…

### DIFF
--- a/_episodes/04-staging-area.md
+++ b/_episodes/04-staging-area.md
@@ -82,9 +82,9 @@ git commit              |          |          |--------->|   commit staged file(
 git commit file(s)      |          |-------------------->|   commit file(s) directly
 
 git diff                |          |<-------->|          |   between modified and staged
-git diff --cached       |          |          |<-------->|   between staged and last commit
-git diff HEAD           |          |<------------------->|   between modified and last commit
-git diff                |          |<------------------->|   if nothing is staged
+git diff --cached       |<------------------->|          |   between staged and last commit
+git diff HEAD           |<-------->|          |          |   between modified and last commit
+git diff                |<-------->|          |          |   if nothing is staged
 
 git reset               |          |<---------|          |   unstage
 git reset --hard        |<---------|          |          |   discard


### PR DESCRIPTION
…mmit

it makes more sense to reference the last commit as unmodified insted of commit in this case.

Sorry, I didn't see it earlier.