### PR TITLE
remotes, conflicts: remove spaces, switch to numbered lists for exerc…

### DIFF
--- a/_episodes/11-remotes.md
+++ b/_episodes/11-remotes.md
@@ -56,15 +56,11 @@ You might use remotes to:
 There are different types of remotes:
 - If you have a server you can ssh to, you can use that as a remote.
 - GitHub is a popular, closed-source commercial site.
-
 - [GitLab](https://about.gitlab.com) is a popular, open-core
   commercial site.  Many universities have their own private GitLabs
   set up.
-
 - [Bitbucket](https://bitbucket.org) is yet another popular commercial site.
-
 - Another option is [NotABug](https://notabug.org)
-
 - **We especially encourage course participants to use our new [Nordic
   research software repository
   platform](https://source.coderefinery.org)**, for more information
@@ -105,9 +101,9 @@ please do so [here](https://github.com/join). But it is OK if you want to use
 
 ## Create a new repository on GitHub
 
-- Login
-- Click on "Repositories"
-- Click on the green button "New"
+1. Login
+2. Click on "Repositories"
+3. Click on the green button "New"
 
 On this page choose a project name (screenshot).
 
@@ -135,9 +131,9 @@ We now want to try the second option that GitHub suggests:
 
 > **... or push an existing repository from the command line**
 
-- Now go to your guacamole repository on your computer.
-- Check that you are in the right place with `git status`.
-- Copy paste the two lines to the terminal and execute those, in my case (**you
+1. Now go to your guacamole repository on your computer.
+2. Check that you are in the right place with `git status`.
+3. Copy paste the two lines to the terminal and execute those, in my case (**you
   need to replace the "bast" part and possibly also the repository name**):
 
 ```shell

--- a/_episodes/12-interrupted.md
+++ b/_episodes/12-interrupted.md
@@ -31,43 +31,31 @@ things.
 
 - `git stash` will put working directory and staging area changes
   away.  Your code will be same as last commit.
-
 - `git stash pop` will return to the state you were before. Can give it a list.
-
 - `git stash list` will list the current stashes.
-
 - `git stash save NAME` is like the first, but will give it a name.
   Useful if it might last a while.
-
 - `git stash save [-p] [filename]` will stash certain files files
   and/or by patches.
-
 - `git stash drop` will drop the most recent stash (or whichever stash
   you give).
-
 - The stashes form a stack, so you can stash several batches of modifications.
 
 
 ### Exercise: stashes
 
-- Make a change.
-
-- Check status/diff, stash the change, check status/diff again.
-
-- Make a separate, unrelated change which doesn't touch the same
+1. Make a change.
+2. Check status/diff, stash the change, check status/diff again.
+3. Make a separate, unrelated change which doesn't touch the same
   lines.  Commit this change.
-
-- Pop off the stash you saved, check status/diff.
-
-- Optional: Do the same but stash twice.  Also check `git stash list`.
+4. Pop off the stash you saved, check status/diff.
+5. Optional: Do the same but stash twice.  Also check `git stash list`.
   Can you pop the stashes in the opposite order?
-
-- Advanced: What happens if stashes conflict with other changes?  make
+6. Advanced: What happens if stashes conflict with other changes?  make
   a change and stash it.  Modify the same line or one right above or
   below.  Pop the stash back.  Resolve the conflict.  Note there is no
   extra commit.
-
-- Advanced: what does `git graph` show when you have something
+7. Advanced: what does `git graph` show when you have something
   stashed?
 
 ---
@@ -96,11 +84,10 @@ Later you can merge it to master or rebase it on top of master and resume work.
 
 You already know how to do this...
 
-- Optional: Go through the process above.  Start a change, create new
+1. Optional: Go through the process above.  Start a change, create new
   branch and store your changes.  Go back to master and fix something
   else.  Resume your work and merge the new branch.
-
-- Discuss how to resume your former work.  Can you git rid of branch?
+2. Discuss how to resume your former work.  Can you git rid of branch?
   Continue using it?  etc.
 
 ---


### PR DESCRIPTION
…ises

- Apparently markdown cares about spaces between list items (unlike
  rst).
- Change examples and exercises to use numbered list.  In future, I
  will try to use the convention "if learner is supposed to follow the
  steps, use numbers, otherwise use bullets" unless there is a reason
  for something else.