### PR TITLE
fix link to the example image of writing commands on whiteboard

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -98,7 +98,7 @@ of commands moving from the "working dir", "staging area", "commits",
 etc is good.
 
 Example:
-![]({{ site.baseurl }}/img/cheat-sheet.jpg)
+![](../img/cheat-sheet.jpg)
 
 
 ## Draw a graph on the board


### PR DESCRIPTION
it didn't work with the site.baseurl since guide.md is in root directory,
and {{ site.baseurl}}/../img (or variants thereof) didn't work either.