### PR TITLE
guide: Update the history view commands to work in more cases

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -81,6 +81,8 @@ tail -n 0 -f demos.out | awk '{ if (match($0,/^[^$]+[$][^ ]* (.*)/,m)) print m[1
 tail -n 0 -f demos.out | awk '{ if (match($0,/^[^@]+@[^$]+[$][^ ]* (.*)/,m)) print m[1] }'
 # Prompt is $ ' alone on a line.
 tail -n 0 -f demos.out | awk '{ if (match($0,/^[$] (.*)/,m)) print m[1] }'
+# used for the fish shell (note: untested)
+tail -f -n 0 ~/fish_history | sed -u -e s'/- cmd:/ \>/'
 ```
 
 

--- a/guide.md
+++ b/guide.md
@@ -70,11 +70,17 @@ command terminates.
 These might work but needs debugging (there are lots of complexities
 in extracting out the right parts), but will get commands as soon as
 they are run and also will capture commands if you `ssh` to somewhere
-else, etc.
+else, etc.  Note: this begins working after the second line you type,
+somehow.
 
 ```
 script -f demos.out
-tail -n 0 -f demos.out | awk '{ if (match($0,/^[^@]+@[^$]+[$][^ ]+ (.*)/,m)) print m[1] }'
+# most general... prompt must end in '$ '.
+tail -n 0 -f demos.out | awk '{ if (match($0,/^[^$]+[$][^ ]* (.*)/,m)) print m[1] }'
+# Standard bash prompt of 'user@host$ ' (less likely to have false positives)
+tail -n 0 -f demos.out | awk '{ if (match($0,/^[^@]+@[^$]+[$][^ ]* (.*)/,m)) print m[1] }'
+# Prompt is $ ' alone on a line.
+tail -n 0 -f demos.out | awk '{ if (match($0,/^[$] (.*)/,m)) print m[1] }'
 ```
 
 


### PR DESCRIPTION
This works in my personal bash and the Aalto default bash.  The previous problem was caused by having a colorized prompt that puts unprintable characters after the `$`.

There is also now an alias for a prompt starting wiht `$ ` on its own line, but it needs testing.
