### PR TITLE
recipe-branching backup repo: checkout the remote branches to make them local.

### DIFF
--- a/_episodes/06-branches.md
+++ b/_episodes/06-branches.md
@@ -264,6 +264,9 @@ The state can be a commit or a branch (pointing to a commit).
 - Step out of the current directory: `$ cd ..`
 - `$ git clone https://github.com/coderefinery/recipe.git recipe-branching`
 - `$ cd recipe-branching`
+- `$ git checkout experiment`
+- `$ git checkout less-salt`
+- `$ git checkout master`
 - `$ git graph`
 - Or call a helper to un-stuck it for you.
 


### PR DESCRIPTION
- Closes: #156
- This is also needed because just `git merge experiment` doesn't work.