### PR TITLE
display link to reference.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ start_time: 570  # 9:30
 # where things are
 source: .
 destination: ./_site
-plugins_dir: ./_plugins
+plugins_dir: ./jekyll-common/plugins
 layouts_dir: ./jekyll-common/layouts
 includes_dir: ./jekyll-common/includes
 data_dir: ./_data

--- a/reference.md
+++ b/reference.md
@@ -1,3 +1,8 @@
+---
+layout: default
+permalink: /reference/
+---
+
 # git-intro quick reference
 
 ## Other cheatsheets


### PR DESCRIPTION
As discussed in https://github.com/coderefinery/jekyll-common/issues/4