### PR TITLE
Revert addition of quick reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ start_time: 570  # 9:30
 # where things are
 source: .
 destination: ./_site
-plugins_dir: ./jekyll-common/plugins
+plugins_dir: ./_plugins
 layouts_dir: ./jekyll-common/layouts
 includes_dir: ./jekyll-common/includes
 data_dir: ./_data

--- a/reference.md
+++ b/reference.md
@@ -1,8 +1,3 @@
----
-layout: default
-permalink: /reference/
----
-
 # git-intro quick reference
 
 ## Other cheatsheets


### PR DESCRIPTION
This is currently causing builds to fail, so reverting until it can be
fixed.

This reverts commit 06b11d956d6f0051cae0537b0715c8e68364932c, reversing
changes made to b19aaff4421618231690fdfd04ba494775adc5bb.