### PR TITLE
reference: divide status-checking from other commands, add git graph

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -29,26 +29,26 @@ permalink: /reference/
 
 ## Commands we use
 
-* **git config**: edit configuration options
-* **git init**: create new repository
-* **git add**:
+* `git config`: edit configuration options
+* `git init`: create new repository
+* `git add`:
   - Add a new file
   - Add a file to staging
-* **git commit**: record a version, add it to current branch
-* **git commit --amend**: amend our last commit
-* **git status**: see status of files - use often!
-* **git log**: see history of commits and their messages, newest first
-* **git diff**: show difference between working directory and last commit
-* **git diff --staged**: show difference between staging area and last commit
-* **git branch**: show which branch we're on
-* **git branch &lt;name&gt;**: create a new branch &lt;name&gt;
-* **git checkout &lt;file&gt;**: checkout last committed version of &lt;file&gt;, losing unstaged changes
-* **git checkout -b &lt;branch-name&gt;**: create a new branch and switch to it
-* **git revert abc123**: create a new commit which reverts commit abc123
-* **git reset --soft abc123**: remove all commits after abc123, but keep their modifications as staged changes
-* **git reset --hard abc123**: remove all commits after abc123, permanently throwing away their changes
-* **git merge &lt;branch-name&gt;**: merge branch &lt;branch-name&gt; into current branch
-* **git grep**: search for patterns in tracked files
-* **git annotate**: find out when a specific line got introduced and by whom
-* **git show**: inspect individual commits
-* **git bisect**: find a commit which broke some functionality
+* `git commit`: record a version, add it to current branch
+* `git commit --amend`: amend our last commit
+* `git status`: see status of files - use often!
+* `git log`: see history of commits and their messages, newest first
+* `git diff`: show difference between working directory and last commit
+* `git diff --staged`: show difference between staging area and last commit
+* `git branch`: show which branch we're on
+* `git branch &lt;name&gt;`: create a new branch &lt;name&gt;
+* `git checkout &lt;file&gt;`: checkout last committed version of &lt;file&gt;, losing unstaged changes
+* `git checkout -b &lt;branch-name&gt;`: create a new branch and switch to it
+* `git revert abc123`: create a new commit which reverts commit abc123
+* `git reset --soft abc123`: remove all commits after abc123, but keep their modifications as staged changes
+* `git reset --hard abc123`: remove all commits after abc123, permanently throwing away their changes
+* `git merge &lt;branch-name&gt;`: merge branch &lt;branch-name&gt; into current branch
+* `git grep`: search for patterns in tracked files
+* `git annotate`: find out when a specific line got introduced and by whom
+* `git show`: inspect individual commits
+* `git bisect`: find a commit which broke some functionality

--- a/reference.md
+++ b/reference.md
@@ -29,17 +29,28 @@ permalink: /reference/
 
 ## Commands we use
 
+Setup:
+
 * `git config`: edit configuration options
 * `git init`: create new repository
+
+See our status:
+
+* `git status`: see status of files - use often!
+* `git log`: see history of commits and their messages, newest first
+* `git graph`: see a detailed graph of commits.  Create this command
+  with `git config --global alias.graph "log --all --graph --decorate --oneline"`
+* `git diff`: show difference between working directory and last commit
+* `git diff --staged`: show difference between staging area and last commit
+* `git show &lt;commit&gt;`: inspect individual commits
+
+General work:
+
 * `git add`:
   - Add a new file
   - Add a file to staging
 * `git commit`: record a version, add it to current branch
 * `git commit --amend`: amend our last commit
-* `git status`: see status of files - use often!
-* `git log`: see history of commits and their messages, newest first
-* `git diff`: show difference between working directory and last commit
-* `git diff --staged`: show difference between staging area and last commit
 * `git branch`: show which branch we're on
 * `git branch &lt;name&gt;`: create a new branch &lt;name&gt;
 * `git checkout &lt;file&gt;`: checkout last committed version of &lt;file&gt;, losing unstaged changes
@@ -50,5 +61,4 @@ permalink: /reference/
 * `git merge &lt;branch-name&gt;`: merge branch &lt;branch-name&gt; into current branch
 * `git grep`: search for patterns in tracked files
 * `git annotate`: find out when a specific line got introduced and by whom
-* `git show`: inspect individual commits
 * `git bisect`: find a commit which broke some functionality


### PR DESCRIPTION
* We should emphasize the commands which are always safe to use, and
  can be used to figure out what's going on.

* `git graph` is a useful command which is easy to miss, if you don't
  see the one place we define it.  Make it and the definition easy to
  find.

* This PR depends on and includes my PR of reformatting the bold to
  monospace.