### PR TITLE
Improve notes that git-switch and git-restore are new commands

### DIFF
--- a/_episodes/06-branches.md
+++ b/_episodes/06-branches.md
@@ -190,7 +190,7 @@ $ git graph
 > Picture `git checkout` as an operation that brings the working tree to a specific state.
 > The state can be a commit or a branch (pointing to a commit).
 >
-> In latest Git this is much nicer:
+> In Git 2.23 (2019-08-16) and later this is much nicer:
 > ```shell
 > $ git switch <branchname>  # switch to a different branch
 > $ git restore <path/file>  # discard changes in working directory

--- a/guide.md
+++ b/guide.md
@@ -270,3 +270,10 @@ there are questions.
 
 Typically only very few learners have background in Subversion or Mercurial and the risk
 is to "waste" 10 minutes on a discussion that nobody can relate to and benefit from.
+
+
+### Todo
+
+`git restore` and `git switch` were added in git 2.23 (released
+2019-08-16).  Sometime much later (2021, 2022, or 2023) perhaps, the
+older alternatives can be demoted or removed.


### PR DESCRIPTION
- State date and version
- Note in instructor's guide that someday, old alternatives can be
  de-emphasized
- Closes: #203