### PR TITLE
removing text which I think is redundant

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,26 +17,12 @@ try to stick to simple workflows, just enough for researchers who aren't
 obsessed with git to be able to work well.  We try to avoid commands which
 might get you into a confusing state.
 
-Our general flow is 10 minutes on "why version control", followed by
-about 45 minutes of the basics of how to make commits.  Then, there are
-several small steps until we get to branching, merging, and conflict
-resolution.
-
-Investigating a past commit and going back in time are also introduced.
-Great emphasis is made about the importance of not changing history of
-shared repositories, when there is a need to undo commits.
-
-Then, we see a little bit about sharing repositories online, how to
-effectively dig into the history of a project,
-and a few other random points before we conclude.
-
 The goals of the module as a whole are that the user will feel comfortable
 about staging changes, committing them, merging, and branching. The guacamole
 example that we use is inspired by [Byron Smith](http://blog.byronjsmith.com),
 for original reference, see [this
 thread](https://carpentries.topicbox.com/groups/discuss/Tfe5ac909d5fb476b).
-If you are teaching this lesson, see the [instructor's guide](guide)
-
+If you are teaching this lesson, see the [instructor's guide](guide).
 
 > ## Prerequisites
 >


### PR DESCRIPTION
- we never have time to go through it before we start
- we have the overview below and a wall of text moves it away from
  screen
- time estimates are outdated anyway
- the instructor should be able to introduce the schedule in words
  without this text based on the schedule and instructor guide