### PR TITLE
Fixed commit hash in the bisect demo 🦗

### DIFF
--- a/_episodes/10-archaeology.md
+++ b/_episodes/10-archaeology.md
@@ -221,7 +221,7 @@ We will probably arrive at a solution which is similar to `git bisect`:
 
 ```shell
 $ git bisect start
-$ git bisect good f0ea950  # this is a commit that worked
+$ git bisect good 7e14f28a  # this is a commit that worked
 $ git bisect bad master    # last commit is broken
   # now compile and/or run
   # after that decide whether


### PR DESCRIPTION
Using the default git clone, original f0ea950 was returning various forms of
`fatal: 'f0ea950' is not a commit`
(depending on a git command)

Replaced with a commit (7e14f28a) recent in history,
so that the demo can be carried on until success.

**Question/option**: Do you prefer 7-char prefix (as in GH and originally), or an 8-char prefix like in `git log --oneline`/`git graph`? Please update if 7-char 😉 THANKS!