### PR TITLE
it seems git grep on windows needs double quotes; closes #275

### DIFF
--- a/_episodes/10-archaeology.md
+++ b/_episodes/10-archaeology.md
@@ -54,6 +54,7 @@ This is useful to find out where in the code some variable is used or some error
 
 ```
 $ git grep sometext
+$ git grep "some text with spaces"
 ```
 
 In the [networkx](https://github.com/networkx/networkx) repository you can try:
@@ -183,7 +184,7 @@ $ git switch --create branchname somehash
 >   ```
 >
 > Then using the above 5 tools try to:
-> - Find the code line which contains `'No links matched that expression'`
+> - Find the code line which contains `"No links matched that expression"`
 > - Find out when this line was last modified. Find the actual commit which modified that line.
 > - Inspect that commit with `git show`.
 > - Create a branch pointing to the past when that commit was created to be able to browse and use the code as it was back then.


### PR DESCRIPTION
adapting the example for that to hopefully avoid
this problem