### PR TITLE
Fix broken eht-imaging links

### DIFF
--- a/_episodes/01-motivation.md
+++ b/_episodes/01-motivation.md
@@ -151,10 +151,10 @@ to produce the Event Horizon Telescope images: [https://github.com/achael/eht-im
 
 - History
   - Explore the [repository](https://github.com/achael/eht-imaging).
-  - Explore the [history](https://github.com/achael/eht-imaging/commits/master).
+  - Explore the [history](https://github.com/achael/eht-imaging/commits/main).
   - Note that there are [branches](https://github.com/achael/eht-imaging/network).
 - Reproducibility
-  - Discuss the enormous value of the annotation feature: [example file](https://github.com/achael/eht-imaging/blame/master/ehtim/imaging/starwarps.py).
+  - Discuss the enormous value of the annotation feature: [example file](https://github.com/achael/eht-imaging/blame/main/ehtim/imaging/starwarps.py).
 - Collaboration
   - You can refer to [code portions](https://github.com/achael/eht-imaging/blob/31361ab62c5718b08612fc75e409795f004f5071/ehtim/imaging/starwarps.py#L66-L75)
     (so much simpler to send a link rather than describe which file to open and where to scroll to).


### PR DESCRIPTION
The eht-im repository has switched their naming from `master` to `main`
branch, so the old links didn't work anymore. They should work now.