### PR TITLE
Use SSH rather than HTTPS for cloning

### DIFF
--- a/_episodes/06-branches.md
+++ b/_episodes/06-branches.md
@@ -283,7 +283,7 @@ $ git graph
 - Step out of the current directory: `$ cd ..`
 - Then:
   ```
-  $ git clone https://github.com/coderefinery/recipe.git recipe-branching
+  $ git clone git@github.com:coderefinery/recipe.git recipe-branching
   $ cd recipe-branching
   $ git checkout experiment
   $ git checkout less-salt


### PR DESCRIPTION
Now CR recommends to use SSH connection and thus probably best to use SSH for cloning?
I requested all three in Git-team for the '21 May CR workshop.
