### PR TITLE
requirements: Add draft version of sphinx-copybutton which excludes prompts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ Sphinx
 sphinx_rtd_theme
 sphinx_rtd_theme_ext_color_contrast
 myst_nb
+# Remove once new sphinx-copybutton is released ( > 0.5.0)
+git+https://github.com/rkdarst/sphinx-copybutton.git@exclude-unselectable-3
 sphinx-lesson
 https://github.com/coderefinery/sphinx-coderefinery-branding/archive/master.zip


### PR DESCRIPTION
- Makes the copy button exclude `$` prompts.
- Review: check the build, don't merge yet.  Depending on outcome,
  this could go straight to sphinx-lesson instead.
