### PR TITLE
Change highlighting from `shell` to `console`

### DIFF
--- a/content/archaeology.md
+++ b/content/archaeology.md
@@ -140,16 +140,16 @@ $ git checkout -b branchname somehash
 Example (lines starting with "#" are only comments):
 
 ```console
-  # create branch called "older-code" from hash 347e6292419b
+$ # create branch called "older-code" from hash 347e6292419b
 $ git checkout -b older-code 347e6292419bd0e4bff077fe971f983932d7a0e9
 
-  # now you can navigate and inspect the code as it was back then
-  # ...
+$ # now you can navigate and inspect the code as it was back then
+$ # ...
 
-  # after we are done we can switch back to "main"
+$ # after we are done we can switch back to "main"
 $ git checkout main
 
-  # if we like we can delete the "older-code" branch
+$ # if we like we can delete the "older-code" branch
 $ git branch -d older-code
 ```
 
@@ -257,17 +257,20 @@ We will probably arrive at a solution which is similar to `git bisect`:
 $ git bisect start
 $ git bisect good f0ea950  # this is a commit that worked
 $ git bisect bad main    # last commit is broken
-  # now compile and/or run
-  # after that decide whether
+
+$ # now compile and/or run
+$ # after that decide whether
 $ git bisect good
-  # or
+$ # or
 $ git bisect bad
-  # now compile and/or run
-  # after that decide whether
+
+$ # now compile and/or run
+$ # after that decide whether
 $ git bisect good
-  # or
+$ # or
 $ git bisect bad
-  # iterate until commit is found
+
+$ # iterate until commit is found
 ```
 
 - This can even be automatized with `git bisect run <script>`.
@@ -335,10 +338,10 @@ $ git bisect bad
   How to navigate to the parent of a commit with hash `somehash`:
 
   ```console
-    # create branch pointing to the parent of somehash
+  $ # create branch pointing to the parent of somehash
   $ git checkout -b branchname somehash~1
 
-    # instead of a tilde you can also use this
+  $ # instead of a tilde you can also use this
   $ git checkout -b branchname somehash^
   ```
 ````

--- a/content/archaeology.md
+++ b/content/archaeology.md
@@ -13,7 +13,7 @@
 ````{prereq} Preparation
 Please make sure that you do not clone repositories inside an already tracked folder:
 
-```shell
+```console
 $ git status
 ```
 
@@ -139,7 +139,7 @@ $ git checkout -b branchname somehash
 
 Example (lines starting with "#" are only comments):
 
-```shell
+```console
   # create branch called "older-code" from hash 347e6292419b
 $ git checkout -b older-code 347e6292419bd0e4bff077fe971f983932d7a0e9
 
@@ -182,7 +182,7 @@ $ git switch --create branchname somehash
   - Clone this repository:
     <https://github.com/networkx/networkx.git>.
     Then step into the new directory and create an exercise branch from the networkx-2.6.3 tag/release:
-    ```
+    ```console
     $ git clone https://github.com/networkx/networkx.git
     $ cd networkx
     $ git checkout -b exercise networkx-2.6.3
@@ -253,7 +253,7 @@ We will probably arrive at a solution which is similar to `git bisect`:
 - First find out a commit in past when it worked.
 - Then bisect your way until you find the commit that broke it.
 
-```shell
+```console
 $ git bisect start
 $ git bisect good f0ea950  # this is a commit that worked
 $ git bisect bad main    # last commit is broken
@@ -297,7 +297,7 @@ $ git bisect bad
   should produce 3.14 but it does not. The script broke at some point and
   produces 3.57 using the last commit:
 
-  ```
+  ```console
   $ python get_pi.py
 
   3.57
@@ -328,13 +328,13 @@ $ git bisect bad
 
   Finding the first commit:
 
-  ```
+  ```console
   $ git log --oneline | tail -n 1
   ```
 
   How to navigate to the parent of a commit with hash `somehash`:
 
-  ```shell
+  ```console
     # create branch pointing to the parent of somehash
   $ git checkout -b branchname somehash~1
 

--- a/content/branches.md
+++ b/content/branches.md
@@ -126,7 +126,7 @@ We do the following part together. Encourage participants to type along.
 
 Let's create a branch called `experiment` where we add cilantro to `ingredients.txt`.
 
-```shell
+```console
 $ git branch experiment master   # create branch called "experiment" from master
                                  # pointing to the present commit
 $ git checkout experiment        # switch to branch "experiment"
@@ -538,7 +538,7 @@ $ git checkout -b <name>   # create branch <name> and switch to it
 
 With this there are two typical workflows:
 
-```shell
+```console
 $ git checkout -b new-feature  # create branch, switch to it
 $ git commit                   # work, work, work, ...
                                # test
@@ -551,7 +551,7 @@ $ git branch -d new-feature    # remove branch
 Sometimes you have a wild idea which does not work.
 Or you want some throw-away branch for debugging:
 
-```shell
+```console
 $ git checkout -b wild-idea
                                # work, work, work, ...
                                # realize it was a bad idea

--- a/content/branches.md
+++ b/content/branches.md
@@ -128,7 +128,7 @@ Let's create a branch called `experiment` where we add cilantro to `ingredients.
 
 ```console
 $ git branch experiment master   # create branch called "experiment" from master
-                                 # pointing to the present commit
+$                                # pointing to the present commit
 $ git checkout experiment        # switch to branch "experiment"
 $ git branch                     # list all local branches and show on which branch we are
 ```
@@ -541,8 +541,8 @@ With this there are two typical workflows:
 ```console
 $ git checkout -b new-feature  # create branch, switch to it
 $ git commit                   # work, work, work, ...
-                               # test
-                               # feature is ready
+$                              # test
+$                              # feature is ready
 $ git checkout master          # switch to master
 $ git merge new-feature        # merge work to master
 $ git branch -d new-feature    # remove branch
@@ -553,11 +553,11 @@ Or you want some throw-away branch for debugging:
 
 ```console
 $ git checkout -b wild-idea
-                               # work, work, work, ...
-                               # realize it was a bad idea
+$                              # work, work, work, ...
+$                              # realize it was a bad idea
 $ git checkout master
 $ git branch -D wild-idea      # it is gone, off to a new idea
-                               # -D because we never merged back
+$                              # -D because we never merged back
 ```
 
 No problem: we worked on a branch, branch is deleted, `master` is clean.

--- a/content/conflicts.md
+++ b/content/conflicts.md
@@ -350,19 +350,19 @@ Follow instructions that you get from the Git command line.
 
   To view what will be removed:
 
-  ```
+  ```console
   $ git clean -n
   ```
 
   To remove:
 
-  ```
-  $ git clean -f
+  ```console
+  $ git clean -f
   ```
 
   To configure Git to avoid creating backups at all:
 
-  ```
+  ```console
   $ git config --global mergetool.keepBackup false
   ```
 ````

--- a/content/interrupted.md
+++ b/content/interrupted.md
@@ -84,7 +84,7 @@ Sounds like a good time to make a feature branch.
 
 You basically know how to do this:
 
-```shell
+```console
 $ git checkout -b temporary  # create a branch and switch to it
 $ git add <paths>            # stage changes
 $ git commit                 # commit them


### PR DESCRIPTION
- The `console` parser treats the `$` as special, which makes it not
  be selectable when selecting the text for copying and pasting.
  `shell` is bash script, which by definition does not have `$` in the
  input/outputs.

- I have looked through all episodes and made modifications where needed.

- The only possible downside is this kind of construct:

  ```
  $ git branch experiment master   # create branch called "experiment" from master
                                   # pointing to the present commit
  $ git checkout experiment        # switch to branch "experiment"
  $ git branch                     # list all local branches and show on which branch we are
  ```

  The second line has `#` which gets parsed as a root prompt, not a
  comment.  Most of the blocks that aren't marked as console already
  had these kind of comments, so maybe it is intentional that they are
  not console?

  I'm thinking it is better to move them to `console` now, the
  highlighting is not perfect, but since we have been discussing `$`
  not being copied, "not copying $" is more important than "prefect
  coloring".  The "#" on the second line will also not be copied,
  which can cause invalid syntax on line 2.

- Review: comment above
