### PR TITLE
content/aliases: for diff, use --staged instead of --cached

### DIFF
--- a/content/aliases.md
+++ b/content/aliases.md
@@ -66,7 +66,7 @@ $ git config --global alias.cl "clone --recursive"
 $ git config --global alias.co checkout
 $ git config --global alias.cop "checkout --patch"
 $ git config --global alias.di diff
-$ git config --global alias.dic "diff --cached --color-words"
+$ git config --global alias.dic "diff --staged --color-words"
 $ git config --global alias.diw "diff --color-words"
 $ git config --global alias.dis "!git --no-pager diff --stat"
 $ git config --global alias.fe fetch


### PR DESCRIPTION
- Only instance of `--cached` which we otherwise don't use.
- `--staged` has been supported since 1.6.1 which is probably safe to
  assume people have by now.
- Review: consider if 1.6.1 is old enough
