### PR TITLE
content/archaeology: change `switch` on newer git to `checkout` on newer git

### DIFF
--- a/content/archaeology.md
+++ b/content/archaeology.md
@@ -141,10 +141,10 @@ $ # if we like we can delete the "older-code" branch
 $ git branch -d older-code
 ```
 
-On newer Git versions this is the preferred command:
+On old Git versions you need to use this:
 
 ```console
-$ git switch --create branchname somehash
+$ git checkout -b BRANCHNAME SOMEHASH
 ```
 
 (exercise-history)=


### PR DESCRIPTION
- The "never git" message now becomes an "older git" note.
